### PR TITLE
fix: ytdlp update fail

### DIFF
--- a/Clients.cs
+++ b/Clients.cs
@@ -71,6 +71,8 @@ public class Clients
                 if (e.Data != null) Logger.Warning(e.Data, Logger.LogSource.ManagementResource);
             };
 
+            SetYtDlpEnv(process.StartInfo);
+
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
@@ -120,11 +122,6 @@ public class Clients
 
     public static async Task ExecYtDlp(string[] args)
     {
-        if (!Directory.Exists(Constraint.TmpDirectory))
-            Directory.CreateDirectory(Constraint.TmpDirectory);
-        if (!Directory.Exists(Constraint.HomeDirectory))
-            Directory.CreateDirectory(Constraint.HomeDirectory);
-
         var startInfo = new ProcessStartInfo
         {
             FileName = Constraint.YtDlpClientPath,
@@ -139,8 +136,7 @@ public class Clients
         pargs = pargs.Where(arg => arg != "--no-cache-dir" && arg != "--rm-cache-dir").ToList();
         foreach (var arg in pargs) startInfo.ArgumentList.Add(arg);
 
-        startInfo.EnvironmentVariables["TEMP"] = startInfo.EnvironmentVariables["TMP"] = Constraint.TmpDirectory;
-        startInfo.EnvironmentVariables["HOME"] = Constraint.HomeDirectory;
+        SetYtDlpEnv(startInfo);
 
         Logger.Info(new string('=', Constraint.LogSeparatorLength) + $"\n[{DateTime.Now:yyyy-MM-dd HH:mm:ss}]  {string.Join(" ", startInfo.ArgumentList)}", Logger.LogSource.YtDlpBridge);
 
@@ -172,5 +168,16 @@ public class Clients
         await process.WaitForExitAsync();
 
         Environment.Exit(process.ExitCode);
+    }
+
+    private static void SetYtDlpEnv(ProcessStartInfo startInfo)
+    {
+        if (!Directory.Exists(Constraint.TmpDirectory))
+            Directory.CreateDirectory(Constraint.TmpDirectory);
+        if (!Directory.Exists(Constraint.HomeDirectory))
+            Directory.CreateDirectory(Constraint.HomeDirectory);
+
+        startInfo.EnvironmentVariables["TEMP"] = startInfo.EnvironmentVariables["TMP"] = Constraint.TmpDirectory;
+        startInfo.EnvironmentVariables["HOME"] = Constraint.HomeDirectory;
     }
 }


### PR DESCRIPTION
This pull request refactors how environment variables are set for yt-dlp processes in `Clients.cs` by introducing a helper method to centralize and simplify environment setup. The main logic for setting up temporary and home directories, as well as the relevant environment variables, has been moved into a new private method, reducing code duplication and improving maintainability.

**Refactoring and Code Simplification:**

* Introduced a new private method `SetYtDlpEnv` to handle the creation of directories and the setting of `TEMP`, `TMP`, and `HOME` environment variables for yt-dlp processes, replacing duplicated logic in multiple methods.
* Updated `ExecYtDlp` and `YtDlpDownloadAndUpdate` to use the new `SetYtDlpEnv` method instead of setting environment variables and creating directories directly. [[1]](diffhunk://#diff-127cbb6da34850a104efd76131f70b2b1a49e0e04aebf2180548b7004c6a8329L142-R139) [[2]](diffhunk://#diff-127cbb6da34850a104efd76131f70b2b1a49e0e04aebf2180548b7004c6a8329R74-R75)
* Removed redundant directory creation code from `ExecYtDlp` since this is now handled by `SetYtDlpEnv`.